### PR TITLE
Double comparisons shouldn't always have a tolerance.

### DIFF
--- a/core/src/main/java/com/google/common/truth/DoubleSubject.java
+++ b/core/src/main/java/com/google/common/truth/DoubleSubject.java
@@ -142,27 +142,15 @@ public final class DoubleSubject extends ComparableSubject<DoubleSubject, Double
     };
   }
 
-  /**
-   * @deprecated Use {@link #isWithin} instead. Double comparison should always have a tolerance.
-   */
-  @Deprecated
   public final void isEqualTo(@Nullable Double other) {
     super.isEqualTo(other);
   }
 
-  /**
-   * @deprecated Use {@link #isNotWithin} instead. Double comparison should always have a tolerance.
-   */
-  @Deprecated
   public final void isNotEqualTo(@Nullable Double other) {
     super.isNotEqualTo(other);
   }
 
-  /**
-   * @deprecated Use {@link #isWithin} instead. Double comparison should always have a tolerance.
-   */
   @Override
-  @Deprecated
   public final void isEquivalentAccordingToCompareTo(Double other) {
     super.isEquivalentAccordingToCompareTo(other);
   }


### PR DESCRIPTION
Forcing callers to pass a tolerance of 0.0 is punative. In one PR I saw
the caller pass a non-zero tolerance because the API leads you that way:

assertThat(summer.sum()).isWithin(0.000001).of(0.0);

For most tests, double math is deterministic and the tolerance is
needless complexity.

Closes: https://github.com/google/truth/issues/187